### PR TITLE
Design HouseLaurent-Challonge interface.

### DIFF
--- a/HouseLaurent/Challonge/ChallongeMatch.cs
+++ b/HouseLaurent/Challonge/ChallongeMatch.cs
@@ -1,0 +1,30 @@
+namespace HouseLaurent.Challonge
+{
+    internal class ChallongeMatch
+    {
+        public int TournamentId { get; }
+
+        public int Id { get; }
+
+        public int Round { get; }
+
+        public int PlayerAId { get; }
+
+        public int PlayerBId { get; }
+
+        public int PlayerAWins { get; }
+
+        public int PlayerBWins { get; }
+
+        public ChallongeMatch(int tournamentId, int id, int round, int playerAId, int playerBId, int playerAWins, int playerBWins)
+        {
+            TournamentId = tournamentId;
+            Id = id;
+            Round = round;
+            PlayerAId = playerAId;
+            PlayerBId = playerBId;
+            PlayerAWins = playerAWins;
+            PlayerBWins = playerBWins;
+        }
+    }
+}

--- a/HouseLaurent/Challonge/ChallongeParticipant.cs
+++ b/HouseLaurent/Challonge/ChallongeParticipant.cs
@@ -1,0 +1,18 @@
+namespace HouseLaurent.Challonge
+{
+    internal class ChallongeParticipant
+    {
+        public int TournamentId { get; }
+
+        public int Id { get; }
+
+        public ChallongeParticipantDescriptor Desc { get; }
+
+        public ChallongeParticipant(int tournamentId, int id, ChallongeParticipantDescriptor desc)
+        {
+            TournamentId = tournamentId;
+            Id = id;
+            Desc = desc;
+        }
+    }
+}

--- a/HouseLaurent/Challonge/ChallongeParticipantDescriptor.cs
+++ b/HouseLaurent/Challonge/ChallongeParticipantDescriptor.cs
@@ -1,0 +1,18 @@
+namespace HouseLaurent.Challonge
+{
+    internal class ChallongeParticipantDescriptor
+    {
+        public string Name { get; }
+
+        public string? ChallongeUsername { get; set; }
+
+        public int Seed { get; }
+
+        public ChallongeParticipantDescriptor(string name, string? challongeUsername, int seed)
+        {
+            Name = name;
+            ChallongeUsername = challongeUsername;
+            Seed = seed;
+        }
+    }
+}

--- a/HouseLaurent/Challonge/ChallongeResponse.cs
+++ b/HouseLaurent/Challonge/ChallongeResponse.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace HouseLaurent.Challonge
+{
+    /// <summary>
+    /// The response from a call to a Challonge API. A <see cref="IChallongeContext"/> may also mimic such a response if it resolves the call locally.
+    /// </summary>
+    internal class ChallongeResponse
+    {
+        /// <summary>
+        /// If <see cref="HttpStatusCode.OK"/>, success. Otherwise, failure.
+        /// </summary>
+        public HttpStatusCode Code { get; }
+
+        /// <summary>
+        /// A list of human-friendly error strings.
+        /// </summary>
+        public IReadOnlyList<string> Errors { get; }
+
+        public ChallongeResponse(HttpStatusCode code, IReadOnlyList<string> errors)
+        {
+            Code = code;
+            Errors = errors;
+        }
+
+        protected ChallongeResponse()
+        {
+            Code = HttpStatusCode.OK;
+            Errors = Array.Empty<string>();
+        }
+
+        public static ChallongeResponse OK => new ChallongeResponse();
+    }
+
+    /// <summary>
+    /// A <see cref="ChallongeResponse"/> with a generic value.
+    /// </summary>
+    internal class ChallongeResponse<TValue> : ChallongeResponse
+    {
+        /// <summary>
+        /// If <see cref="ChallongeResponse.Code"/> is <see cref="HttpStatusCode.OK"/>, some meaningful value. Otherwise, null or some garbage value.
+        /// </summary>
+        public TValue Value { get; }
+
+        public ChallongeResponse(HttpStatusCode code, IReadOnlyList<string> errors, TValue value) : base(code, errors)
+        {
+            Value = value;
+        }
+
+        public ChallongeResponse(TValue value) : base()
+        {
+            Value = value;
+        }
+
+        public static implicit operator ChallongeResponse<TValue>(TValue value) => new ChallongeResponse<TValue>(value);
+    }
+}

--- a/HouseLaurent/Challonge/ChallongeSyncResult.cs
+++ b/HouseLaurent/Challonge/ChallongeSyncResult.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+
+namespace HouseLaurent.Challonge
+{
+    /// <summary>
+    /// The result of a single Challonge tournament's synchronization between HouseLaurent (local) and Challonge (remote). See <see cref="IChallongeContext.SyncTournament"/>.
+    /// </summary>
+    internal class ChallongeSyncResult
+    {
+        /// <summary>
+        /// The old tournament as tracked by Challonge before a <see cref="IChallongeContext"/> pushed its modified version from HouseLaurent to Challonge. If null, there was no difference between HouseLaurent and Challonge.
+        /// </summary>
+        public ChallongeTournament? TournamentModified { get; }
+
+        /// <summary>
+        /// A list of old tournament participants that were tracked by both HouseLaurent and Challonge with differences. Each list item is as tracked by Challonge before a <see cref="IChallongeContext"/> pushed its modified version from HouseLaurent to Challonge.
+        /// </summary>
+        public IReadOnlyList<ChallongeParticipant> ParticipantsModified { get; }
+
+        /// <summary>
+        /// A list of tournament particpants that were tracked by HouseLaurent but untracked by Challonge. Each list item is a participant that a <see cref="IChallongeContext"/> added to Challonge.
+        /// </summary>
+        public IReadOnlyList<ChallongeParticipant> ParticipantsAdded { get; }
+
+        /// <summary>
+        /// A list of tournament particpants that were untracked by HouseLaurent but tracked by Challonge. Each list item is a participant that a <see cref="IChallongeContext"/> deleted from Challonge.
+        /// </summary>
+        public IReadOnlyList<ChallongeParticipant> ParticipantsDeleted { get; }
+
+        /// <summary>
+        /// A list of old tournament matches that were tracked by both HouseLaurent and Challonge with differences. Each list item is as tracked by Challonge before a <see cref="IChallongeContext"/> pushed its modified version from HouseLaurent to Challonge.
+        /// </summary>
+        public IReadOnlyList<ChallongeMatch> MatchesModified { get; }
+
+        /// <summary>
+        /// A list of tournament matches currently untracked by HouseLaurent but tracked by Challonge. HouseLaurent is advised to add these matches.
+        /// </summary>
+        public IReadOnlyList<ChallongeMatch> UntrackedLocalMatches { get; }
+
+        /// <summary>
+        /// A list of tournament matches currently tracked by HouseLaurent but untracked by Challonge. HouseLaurent is advised to delete these matches.
+        /// </summary>
+        public IReadOnlyList<ChallongeMatch> UntrackedRemoteMatches { get; }
+
+        public ChallongeSyncResult(ChallongeTournament? tournamentModified, IReadOnlyList<ChallongeParticipant> participantsModified, IReadOnlyList<ChallongeParticipant> participantsAdded, IReadOnlyList<ChallongeParticipant> participantsDeleted, IReadOnlyList<ChallongeMatch> matchesModified, IReadOnlyList<ChallongeMatch> untrackedLocalMatches, IReadOnlyList<ChallongeMatch> untrackedRemoteMatches)
+        {
+            TournamentModified = tournamentModified;
+            ParticipantsModified = participantsModified;
+            ParticipantsAdded = participantsAdded;
+            ParticipantsDeleted = participantsDeleted;
+            MatchesModified = matchesModified;
+            UntrackedLocalMatches = untrackedLocalMatches;
+            UntrackedRemoteMatches = untrackedRemoteMatches;
+        }
+    }
+}

--- a/HouseLaurent/Challonge/ChallongeTournament.cs
+++ b/HouseLaurent/Challonge/ChallongeTournament.cs
@@ -1,0 +1,16 @@
+namespace HouseLaurent.Challonge
+{
+    internal class ChallongeTournament
+    {
+        public int Id { get; }
+
+        public ChallongeTournamentDescriptor Desc { get; }
+
+        public ChallongeTournament(int id, ChallongeTournamentDescriptor desc)
+        {
+            Id = id;
+            Desc = desc;
+        }
+
+    }
+}

--- a/HouseLaurent/Challonge/ChallongeTournamentDescriptor.cs
+++ b/HouseLaurent/Challonge/ChallongeTournamentDescriptor.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace HouseLaurent.Challonge
+{
+    internal class ChallongeTournamentDescriptor
+    {
+        public string Name { get; }
+
+        public DateTimeOffset StartTime { get; }
+
+        /// <summary>
+        /// Path as in challonge.com/{UrlPath}
+        /// </summary>
+        public string? UrlPath { get; private set; }
+
+        public string? Description { get; private set; }
+
+        public ChallongeTournamentKind TournamentKind { get; private set; }
+
+        public bool? HoldSingleElimThirdPlaceMatch { get; private set; }
+
+        /// <summary>
+        /// <list type="bullet">
+        /// <item>0 if there aren't grand finals between the W bracket winner and L bracket winner.</item>
+        /// <item>1 if the L bracket winner only needs to beat the W bracket winner once.</item>
+        /// <item>2 if the L bracket winner needs to beat the W bracket winner twice.</item>
+        /// </list>
+        /// </summary>
+        public int? DoubleElimGrandFinalsCount { get; private set; }
+
+        public int? SwissRoundCount { get; private set; }
+
+        private ChallongeTournamentDescriptor(string name, DateTimeOffset startTime)
+        {
+            Name = name;
+            StartTime = startTime;
+        }
+
+        public static ChallongeTournamentDescriptor CreateSingleElim(string name, DateTimeOffset startTime, string? urlPath, string? description, bool holdThirdPlaceMatch)
+        {
+            return new ChallongeTournamentDescriptor(name, startTime)
+            {
+                UrlPath = urlPath,
+                Description = description,
+                TournamentKind = ChallongeTournamentKind.SingleElimination,
+                HoldSingleElimThirdPlaceMatch = holdThirdPlaceMatch,
+            };
+        }
+
+        public static ChallongeTournamentDescriptor CreateDoubleElim(string name, DateTimeOffset startTime, string? urlPath, string? description, int grandFinalsCount)
+        {
+            return new ChallongeTournamentDescriptor(name, startTime)
+            {
+                UrlPath = urlPath,
+                Description = description,
+                TournamentKind = ChallongeTournamentKind.DoubleElimination,
+                DoubleElimGrandFinalsCount = grandFinalsCount,
+            };
+        }
+
+        public static ChallongeTournamentDescriptor CreateRoundRobin(string name, DateTimeOffset startTime, string? urlPath, string? description)
+        {
+            return new ChallongeTournamentDescriptor(name, startTime)
+            {
+                UrlPath = urlPath,
+                Description = description,
+                TournamentKind = ChallongeTournamentKind.RoundRobin,
+            };
+        }
+
+        public static ChallongeTournamentDescriptor CreateSwiss(string name, DateTimeOffset startTime, string? urlPath, string? description, int roundCount)
+        {
+            return new ChallongeTournamentDescriptor(name, startTime)
+            {
+                UrlPath = urlPath,
+                Description = description,
+                TournamentKind = ChallongeTournamentKind.Swiss,
+                SwissRoundCount = roundCount,
+            };
+        }
+    }
+}

--- a/HouseLaurent/Challonge/ChallongeTournamentKind.cs
+++ b/HouseLaurent/Challonge/ChallongeTournamentKind.cs
@@ -1,0 +1,11 @@
+namespace HouseLaurent.Challonge
+{
+    internal enum ChallongeTournamentKind
+    {
+        Unknown = default,
+        SingleElimination,
+        DoubleElimination,
+        RoundRobin,
+        Swiss,
+    }
+}

--- a/HouseLaurent/Challonge/IChallongeContext.cs
+++ b/HouseLaurent/Challonge/IChallongeContext.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+
+namespace HouseLaurent.Challonge
+{
+    /// <summary>
+    /// A context representing a single Challonge account with the tools to create and run tournaments using that account. Some methods are 1:1 bindings to Challonge APIs, while others are abstract connections to Challonge. Either way, each method returns a <see cref="ChallongeResponse"/>.
+    /// </summary>
+    internal interface IChallongeContext
+    {
+        #region Account APIs
+
+        ChallongeResponse<ChallongeTournament> CreateTournament(ChallongeTournamentDescriptor tournamentDesc);
+
+        /// <summary>
+        /// A tool for syncing the state of a single Challonge tournament (as well as the states of all its associated participants and matches) between HouseLaurent (local) and Challonge (remote).
+        /// </summary>
+        /// <param name="tournament">The local tournament state.</param>
+        /// <param name="participants">A list of all local participant states associated with the tournament.</param>
+        /// <param name="matches">A list of all local match states associated with the tournament.</param>
+        /// <remarks>
+        /// This method is responsible for pushing the following state changes from local to remote:
+        /// <list type="bullet">
+        /// <item>If the local and remote tournaments have differences, this method MUST update the tournament on remote.</item>
+        /// <item>If a participant is tracked by both local and remote with differences, this method MUST update the participant on remote.</item>
+        /// <item>If a participant is tracked by local but untracked by remote, this method MUST add the participant to remote.</item>
+        /// <item>If a participant is untracked by local but tracked by remote, this method MUST remove the participant from remote.</item>
+        /// <item>If a match is tracked by both local and remote with differences, this method MUST update the match on remote.</item>
+        /// </list>
+        /// The context MUST return an error response if it can't successfully push one or more state changes. Local and remote should only be out-of-sync if something went wrong: a 5xx error, a human manually updating the tournament on challonge.com, a HouseLaurent bug, etc.
+        /// </remarks>
+        ChallongeResponse<ChallongeSyncResult> SyncTournament(ChallongeTournament tournament, IReadOnlyList<ChallongeParticipant> participants, IReadOnlyList<ChallongeMatch> matches);
+
+        #endregion
+
+        #region Tournament APIs
+
+        ChallongeResponse<ChallongeTournament> GetTournament(int tournamentId);
+
+        ChallongeResponse UpdateTournament(int tournamentId, ChallongeTournamentDescriptor tournamentDesc);
+
+        ChallongeResponse<IReadOnlyList<ChallongeParticipant>> GetParticipants(int tournamentId);
+
+        ChallongeResponse<IReadOnlyList<ChallongeMatch>> GetMatches(int tournamentId);
+
+        ChallongeResponse StartTournament(int tournamentId);
+
+        ChallongeResponse<ChallongeParticipant> RegisterPlayer(int tournamentId, ChallongeParticipantDescriptor participantDesc);
+
+        ChallongeResponse<IReadOnlyList<ChallongeParticipant>> RegisterPlayers(int tournamentId, IReadOnlyList<ChallongeParticipantDescriptor> participantDescs);
+
+        ChallongeResponse ResetTournament(int tournamentId);
+
+        /// <summary>
+        /// Finalize all match scores from the ongoing round, thereby prompting Challonge to generate the next round's matches.
+        /// </summary>
+        /// <param name="tournamentId">The tournament.</param>
+        /// <param name="roundMatches">A list of all matches from the ongoing round, each with its final score. If <see cref="ChallongeMatch.Round"/> doesn't match the ongoing round, the match is invalid and this method should return in error.</param>
+        /// <param name="preRoundDrops">A list of participant IDs of players that dropped before their match started.</param>
+        /// <param name="postRoundDrops">A list of participant IDs of players that dropped after their match ended.</param>
+        /// <remarks>
+        /// A pre-round drop signifies that the players played zero games in their match, because one player or both players dropped/no-showed after Challonge generated the round.<br/>
+        /// A post-round drop signifies that the players played at least one game in the match, before one player or both players dropped. It may instead signify that a player with a bye dropped at any time during the round.<br/>
+        /// Use <see cref="UpdateMatch"/> instead to live-update game scores.
+        /// </remarks>
+        ChallongeResponse FinalizeRound(int tournamentId, IReadOnlyList<ChallongeMatch> roundMatches, IReadOnlyList<int> preRoundDrops, IReadOnlyList<int> postRoundDrops);
+
+        ChallongeResponse FinalizeTournament(int tournamentId);
+
+        #endregion
+
+        #region Participant APIs
+
+        ChallongeResponse<ChallongeParticipant> GetParticipant(int tournamentId, int participantId);
+
+        ChallongeResponse UpdateParticipant(int tournamentId, int participantId, ChallongeParticipantDescriptor participantDesc);
+
+        ChallongeResponse UnregisterParticipant(int tournamentId, int participantId);
+
+        ChallongeResponse CheckInParticipant(int tournamentId, int participantId);
+
+        ChallongeResponse UnCheckInParticipant(int tournamentId, int participantId);
+
+        #endregion
+
+        #region Match APIs
+
+        ChallongeResponse<ChallongeMatch> GetMatch(int tournamentId, int matchId);
+
+        ChallongeResponse MarkMatchUnderway(int tournamentId, int matchId);
+
+        ChallongeResponse UnmarkMatchUnderway(int tournamentId, int matchId);
+
+        /// <summary>
+        /// Update a match's score without setting the winner, which is instead the responsibility of <see cref="FinalizeRound"/>.
+        /// </summary>
+        ChallongeResponse UpdateMatch(int tournamentId, int matchId, int playerAWins, int playerBWins);
+
+        #endregion
+    }
+}

--- a/HouseLaurent/Challonge/IChallongeContext.cs
+++ b/HouseLaurent/Challonge/IChallongeContext.cs
@@ -1,15 +1,16 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace HouseLaurent.Challonge
 {
     /// <summary>
-    /// A context representing a single Challonge account with the tools to create and run tournaments using that account. Some methods are 1:1 bindings to Challonge APIs, while others are abstract connections to Challonge. Either way, each method returns a <see cref="ChallongeResponse"/>.
+    /// A context representing a single Challonge account with the tools to create and run tournaments using that account. Some methods are 1:1 bindings to Challonge APIs, while others are abstract connections to Challonge. Either way, each method asynchronously returns a <see cref="ChallongeResponse"/>.
     /// </summary>
     internal interface IChallongeContext
     {
         #region Account APIs
 
-        ChallongeResponse<ChallongeTournament> CreateTournament(ChallongeTournamentDescriptor tournamentDesc);
+        Task<ChallongeResponse<ChallongeTournament>> CreateTournament(ChallongeTournamentDescriptor tournamentDesc);
 
         /// <summary>
         /// A tool for syncing the state of a single Challonge tournament (as well as the states of all its associated participants and matches) between HouseLaurent (local) and Challonge (remote).
@@ -28,27 +29,27 @@ namespace HouseLaurent.Challonge
         /// </list>
         /// The context MUST return an error response if it can't successfully push one or more state changes. Local and remote should only be out-of-sync if something went wrong: a 5xx error, a human manually updating the tournament on challonge.com, a HouseLaurent bug, etc.
         /// </remarks>
-        ChallongeResponse<ChallongeSyncResult> SyncTournament(ChallongeTournament tournament, IReadOnlyList<ChallongeParticipant> participants, IReadOnlyList<ChallongeMatch> matches);
+        Task<ChallongeResponse<ChallongeSyncResult>> SyncTournament(ChallongeTournament tournament, IReadOnlyList<ChallongeParticipant> participants, IReadOnlyList<ChallongeMatch> matches);
 
         #endregion
 
         #region Tournament APIs
 
-        ChallongeResponse<ChallongeTournament> GetTournament(int tournamentId);
+        Task<ChallongeResponse<ChallongeTournament>> GetTournament(int tournamentId);
 
-        ChallongeResponse UpdateTournament(int tournamentId, ChallongeTournamentDescriptor tournamentDesc);
+        Task<ChallongeResponse> UpdateTournament(int tournamentId, ChallongeTournamentDescriptor tournamentDesc);
 
-        ChallongeResponse<IReadOnlyList<ChallongeParticipant>> GetParticipants(int tournamentId);
+        Task<ChallongeResponse<IReadOnlyList<ChallongeParticipant>>> GetParticipants(int tournamentId);
 
-        ChallongeResponse<IReadOnlyList<ChallongeMatch>> GetMatches(int tournamentId);
+        Task<ChallongeResponse<IReadOnlyList<ChallongeMatch>>> GetMatches(int tournamentId);
 
-        ChallongeResponse StartTournament(int tournamentId);
+        Task<ChallongeResponse> StartTournament(int tournamentId);
 
-        ChallongeResponse<ChallongeParticipant> RegisterPlayer(int tournamentId, ChallongeParticipantDescriptor participantDesc);
+        Task<ChallongeResponse<ChallongeParticipant>> RegisterPlayer(int tournamentId, ChallongeParticipantDescriptor participantDesc);
 
-        ChallongeResponse<IReadOnlyList<ChallongeParticipant>> RegisterPlayers(int tournamentId, IReadOnlyList<ChallongeParticipantDescriptor> participantDescs);
+        Task<ChallongeResponse<IReadOnlyList<ChallongeParticipant>>> RegisterPlayers(int tournamentId, IReadOnlyList<ChallongeParticipantDescriptor> participantDescs);
 
-        ChallongeResponse ResetTournament(int tournamentId);
+        Task<ChallongeResponse> ResetTournament(int tournamentId);
 
         /// <summary>
         /// Finalize all match scores from the ongoing round, thereby prompting Challonge to generate the next round's matches.
@@ -62,38 +63,38 @@ namespace HouseLaurent.Challonge
         /// A post-round drop signifies that the players played at least one game in the match, before one player or both players dropped. It may instead signify that a player with a bye dropped at any time during the round.<br/>
         /// Use <see cref="UpdateMatch"/> instead to live-update game scores.
         /// </remarks>
-        ChallongeResponse FinalizeRound(int tournamentId, IReadOnlyList<ChallongeMatch> roundMatches, IReadOnlyList<int> preRoundDrops, IReadOnlyList<int> postRoundDrops);
+        Task<ChallongeResponse> FinalizeRound(int tournamentId, IReadOnlyList<ChallongeMatch> roundMatches, IReadOnlyList<int> preRoundDrops, IReadOnlyList<int> postRoundDrops);
 
-        ChallongeResponse FinalizeTournament(int tournamentId);
+        Task<ChallongeResponse> FinalizeTournament(int tournamentId);
 
         #endregion
 
         #region Participant APIs
 
-        ChallongeResponse<ChallongeParticipant> GetParticipant(int tournamentId, int participantId);
+        Task<ChallongeResponse<ChallongeParticipant>> GetParticipant(int tournamentId, int participantId);
 
-        ChallongeResponse UpdateParticipant(int tournamentId, int participantId, ChallongeParticipantDescriptor participantDesc);
+        Task<ChallongeResponse> UpdateParticipant(int tournamentId, int participantId, ChallongeParticipantDescriptor participantDesc);
 
-        ChallongeResponse UnregisterParticipant(int tournamentId, int participantId);
+        Task<ChallongeResponse> UnregisterParticipant(int tournamentId, int participantId);
 
-        ChallongeResponse CheckInParticipant(int tournamentId, int participantId);
+        Task<ChallongeResponse> CheckInParticipant(int tournamentId, int participantId);
 
-        ChallongeResponse UnCheckInParticipant(int tournamentId, int participantId);
+        Task<ChallongeResponse> UnCheckInParticipant(int tournamentId, int participantId);
 
         #endregion
 
         #region Match APIs
 
-        ChallongeResponse<ChallongeMatch> GetMatch(int tournamentId, int matchId);
+        Task<ChallongeResponse<ChallongeMatch>> GetMatch(int tournamentId, int matchId);
 
-        ChallongeResponse MarkMatchUnderway(int tournamentId, int matchId);
+        Task<ChallongeResponse> MarkMatchUnderway(int tournamentId, int matchId);
 
-        ChallongeResponse UnmarkMatchUnderway(int tournamentId, int matchId);
+        Task<ChallongeResponse> UnmarkMatchUnderway(int tournamentId, int matchId);
 
         /// <summary>
         /// Update a match's score without setting the winner, which is instead the responsibility of <see cref="FinalizeRound"/>.
         /// </summary>
-        ChallongeResponse UpdateMatch(int tournamentId, int matchId, int playerAWins, int playerBWins);
+        Task<ChallongeResponse> UpdateMatch(int tournamentId, int matchId, int playerAWins, int playerBWins);
 
         #endregion
     }

--- a/HouseLaurent/HouseLaurent.csproj
+++ b/HouseLaurent/HouseLaurent.csproj
@@ -6,6 +6,11 @@
     <Version>0.1.0</Version>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Bjerg" Version="0.1.0" />
     <PackageReference Include="Unterwalden" Version="0.1.0" />


### PR DESCRIPTION
@Kipx
Draft of [a monolithic Challonge interface](https://github.com/TheMostCuriousThing/HouseLaurent/blob/a032ab917114a6e60ffbfc7386d418fd8eba65e7/HouseLaurent/Challonge/IChallongeContext.cs). Most of the methods should be self-evident (some map 1:1 with Challonge) so I didn't clutter with too much documentation...the two big exceptions being `SyncTournament` (we need something like this for robustness because a dozen things can go awry) and `FinalizeRound` (we need something like this because of how sloppily Challonge handles drops and rounds ends).

`IChallongeContext` is a bit of a departure from my original plan because I quickly realized that forcing Challonge to fit a more generalized tournament interface may be futile. A HouseLaurent tournament using Challonge sorta unavoidably needs some knowledge of "Challonge". One of the upsides is that a `IChallongeContext` should be easier to implement (the two methods above maybe posing the biggest challenge).

Questions:
- What dependencies would a Challonge context implementation need? An API key of course. Anything else? Likely an `HttpClient` or similar depending on how an implementation calls Challonge APIs.
- Is this design missing anything? ...considering that this interface doesn't need comprehensive knowledge of every single Challonge endpoint.
- Is anything unintuitive? Is anything confusing?